### PR TITLE
feat: Add emissionDate field to Payable creation

### DIFF
--- a/src/domain/application/services/assignor/create-assignor.ts
+++ b/src/domain/application/services/assignor/create-assignor.ts
@@ -1,6 +1,7 @@
 import { Either, right } from '@/@shared/either'
 import { EntityId } from '@/@shared/entities/entity-id'
 import { Assignor } from '@/domain/enterprise/entities/assignor'
+import { Injectable } from '@nestjs/common'
 import { AssignorRepository } from '../../repositories/assignor-repository'
 
 export type CreateAssignorServiceRequest = {
@@ -13,6 +14,7 @@ export type CreateAssignorServiceRequest = {
 
 export type CreateAssignorServiceResponse = Either<Error, Assignor>
 
+@Injectable()
 export class CreateAssignorService {
   constructor(private readonly AssignorRepository: AssignorRepository) {}
 

--- a/src/domain/application/services/assignor/delete-assignor.ts
+++ b/src/domain/application/services/assignor/delete-assignor.ts
@@ -1,4 +1,5 @@
 import { Either, left, right } from '@/@shared/either'
+import { Injectable } from '@nestjs/common'
 import { AssignorNonExistsError } from '../../errors/AssignorNonExistsError'
 import { InactiveAssignorError } from '../../errors/InactiveAssignorError'
 import { AssignorRepository } from '../../repositories/assignor-repository'
@@ -10,6 +11,7 @@ type DeleteAssignorServiceRequest = {
 
 type DeleteAssignorServiceResponse = Either<AssignorNonExistsError, boolean>
 
+@Injectable()
 export class DeleteAssignorService {
   constructor(private assignorRepository: AssignorRepository) {}
 

--- a/src/domain/application/services/assignor/find-assignor-by-id.ts
+++ b/src/domain/application/services/assignor/find-assignor-by-id.ts
@@ -1,5 +1,6 @@
 import { Either, left, right } from '@/@shared/either'
 import { Assignor } from '@/domain/enterprise/entities/assignor'
+import { Injectable } from '@nestjs/common'
 import { AssignorNonExistsError } from '../../errors/AssignorNonExistsError'
 import { AssignorRepository } from '../../repositories/assignor-repository'
 
@@ -10,6 +11,7 @@ type FindAssignorByIdServiceRequest = {
 
 type FindAssignorByIdServiceResponse = Either<AssignorNonExistsError, Assignor>
 
+@Injectable()
 export class FindAssignorByIdService {
   constructor(private assignorRepository: AssignorRepository) {}
 

--- a/src/domain/application/services/assignor/find-assignors.ts
+++ b/src/domain/application/services/assignor/find-assignors.ts
@@ -1,4 +1,5 @@
 import { Either, left, right } from '@/@shared/either'
+import { Injectable } from '@nestjs/common'
 import { PaginationError } from '../../errors/PaginationError'
 import {
   AssignorRepository,
@@ -16,6 +17,7 @@ type FindAssignorsServiceResponse = Either<
   FindAssignorsResponse
 >
 
+@Injectable()
 export class FindAssignorsService {
   constructor(private assignorRepository: AssignorRepository) {}
 

--- a/src/domain/application/services/assignor/update-assignor.ts
+++ b/src/domain/application/services/assignor/update-assignor.ts
@@ -1,5 +1,6 @@
 import { Either, left, right } from '@/@shared/either'
 import { Assignor } from '@/domain/enterprise/entities/assignor'
+import { Injectable } from '@nestjs/common'
 import { AssignorNonExistsError } from '../../errors/AssignorNonExistsError'
 import { AssignorRepository } from '../../repositories/assignor-repository'
 
@@ -14,6 +15,7 @@ type EditAssignorServiceRequest = {
 
 type UpdateAssignorServiceResponse = Either<AssignorNonExistsError, Assignor>
 
+@Injectable()
 export class UpdateAssignorService {
   constructor(private assignorRepository: AssignorRepository) {}
 

--- a/src/domain/application/services/payable/create-payable.ts
+++ b/src/domain/application/services/payable/create-payable.ts
@@ -12,7 +12,6 @@ import { UserRepository } from '../../repositories/user-repository'
 
 export type CreatePayableServiceRequest = {
   value: number
-  emissionDate: Date
   assignorId: string
   receiverId: string
 }
@@ -35,7 +34,6 @@ export class CreatePayableService {
 
   async execute({
     value,
-    emissionDate,
     assignorId,
     receiverId,
   }: CreatePayableServiceRequest): Promise<CreatePayableServiceResponse> {
@@ -64,7 +62,6 @@ export class CreatePayableService {
 
     const payable = Payable.create({
       value,
-      emissionDate,
       assignorId: new EntityId(assignorId),
       receiverId: new EntityId(receiverId),
     })

--- a/src/domain/application/services/payable/create-payable.unit.spec.ts
+++ b/src/domain/application/services/payable/create-payable.unit.spec.ts
@@ -1,22 +1,66 @@
+import { EntityId } from '@/@shared/entities/entity-id'
+import { Assignor } from '@/domain/enterprise/entities/assignor'
+import { User } from '@/domain/enterprise/entities/user'
+import { InMemoryAssignorRepository } from 'test/repositories/InMemoryAssignorRepository'
 import { InMemoryPayableRepository } from 'test/repositories/InMemoryPayableRepository'
+import { InMemoryUserRepository } from 'test/repositories/InMemoryUserRepository'
 import { CreatePayableService } from './create-payable'
 
 let sut: CreatePayableService
 let inMemoryPayableRepository: InMemoryPayableRepository
+let inMemoryAssignorRepository: InMemoryAssignorRepository
+let inMemoryUserRepository: InMemoryUserRepository
 
 describe('Create Payable', () => {
   beforeEach(() => {
     inMemoryPayableRepository = new InMemoryPayableRepository()
-    sut = new CreatePayableService(inMemoryPayableRepository)
+    inMemoryAssignorRepository = new InMemoryAssignorRepository()
+    inMemoryUserRepository = new InMemoryUserRepository()
+    sut = new CreatePayableService(
+      inMemoryPayableRepository,
+      inMemoryAssignorRepository,
+      inMemoryUserRepository,
+    )
   })
 
   it('should be able to create a new payable', async () => {
+    inMemoryAssignorRepository.createAssignor(
+      Assignor.create(
+        {
+          name: 'John Doe',
+          email: 'johndoe@email.com',
+          document: '12345678910',
+          phone: '12345678910',
+          active: true,
+          creatorId: new EntityId('receiver-id'),
+        },
+        new EntityId('assignor-id'),
+      ),
+    )
+
+    console.log(inMemoryAssignorRepository.assignors)
+
+    inMemoryUserRepository.createUser(
+      User.create(
+        {
+          name: 'John Doe',
+          email: 'johndoe@email.com',
+          password: '12345678',
+          active: true,
+        },
+        new EntityId('receiver-id'),
+      ),
+    )
+
+    console.log(inMemoryUserRepository.users)
+
     const response = await sut.execute({
       assignorId: 'assignor-id',
-      emissionDate: new Date(),
       receiverId: 'receiver-id',
       value: 100,
     })
+
+    console.log(response)
 
     expect(response.isRight()).toBeTruthy()
     expect(response.value).toHaveProperty('id')

--- a/src/domain/application/services/payable/delete-payable.ts
+++ b/src/domain/application/services/payable/delete-payable.ts
@@ -1,4 +1,5 @@
 import { Either, left, right } from '@/@shared/either'
+import { Injectable } from '@nestjs/common'
 import { InactivePayableError } from '../../errors/InactivePayableError'
 import { PayableNonExistsError } from '../../errors/PayableNonExists'
 import { PayableRepository } from '../../repositories/payable-repository'
@@ -13,6 +14,7 @@ type DeletePayableServiceResponse = Either<
   boolean
 >
 
+@Injectable()
 export class DeletePayableService {
   constructor(private payableRepository: PayableRepository) {}
 

--- a/src/domain/application/services/payable/find-payable-by-id.ts
+++ b/src/domain/application/services/payable/find-payable-by-id.ts
@@ -1,5 +1,6 @@
 import { Either, left, right } from '@/@shared/either'
 import { Payable } from '@/domain/enterprise/entities/payable'
+import { Injectable } from '@nestjs/common'
 import { PayableNonExistsError } from '../../errors/PayableNonExists'
 import { PayableRepository } from '../../repositories/payable-repository'
 
@@ -10,6 +11,7 @@ type FindPayableByIdServiceRequest = {
 
 type FindPayableByIdServiceResponse = Either<PayableNonExistsError, Payable>
 
+@Injectable()
 export class FindPayableByIdService {
   constructor(private payableRepository: PayableRepository) {}
 

--- a/src/domain/application/services/payable/find-payables.ts
+++ b/src/domain/application/services/payable/find-payables.ts
@@ -1,4 +1,5 @@
 import { Either, left, right } from '@/@shared/either'
+import { Injectable } from '@nestjs/common'
 import { PaginationError } from '../../errors/PaginationError'
 import {
   FindPayablesResponse,
@@ -13,6 +14,7 @@ type FindPayablesServiceRequest = {
 
 type FindPayablesServiceResponse = Either<PaginationError, FindPayablesResponse>
 
+@Injectable()
 export class FindPayablesService {
   constructor(private payableRepository: PayableRepository) {}
 

--- a/src/domain/application/services/payable/update-payable.ts
+++ b/src/domain/application/services/payable/update-payable.ts
@@ -1,6 +1,7 @@
 import { Either, left, right } from '@/@shared/either'
 import { EntityId } from '@/@shared/entities/entity-id'
 import { Payable } from '@/domain/enterprise/entities/payable'
+import { Injectable } from '@nestjs/common'
 import { PayableNonExistsError } from '../../errors/PayableNonExists'
 import { PayableRepository } from '../../repositories/payable-repository'
 
@@ -14,6 +15,7 @@ type UpdatePayableServiceRequest = {
 
 type UpdatePayableServiceResponse = Either<PayableNonExistsError, Payable>
 
+@Injectable()
 export class UpdatePayableService {
   constructor(private payableRepository: PayableRepository) {}
 

--- a/src/domain/enterprise/entities/payable.ts
+++ b/src/domain/enterprise/entities/payable.ts
@@ -61,12 +61,13 @@ export class Payable extends Entity<PayableProps> {
   }
 
   static create(
-    props: Optional<PayableProps, 'received' | 'active'>,
+    props: Optional<PayableProps, 'received' | 'active' | 'emissionDate'>,
     id?: EntityId,
   ): Payable {
     const payable = new Payable(
       {
         ...props,
+        emissionDate: props.emissionDate ?? new Date(),
         received: props.received ?? false,
         active: props.active ?? true,
       },

--- a/src/infra/database/database.module.ts
+++ b/src/infra/database/database.module.ts
@@ -1,6 +1,10 @@
+import { AssignorRepository } from '@/domain/application/repositories/assignor-repository'
+import { PayableRepository } from '@/domain/application/repositories/payable-repository'
 import { UserRepository } from '@/domain/application/repositories/user-repository'
 import { Module } from '@nestjs/common'
 import { PrismaService } from './prisma/prisma.service'
+import { PrismaAssignorRepository } from './prisma/repositories/prisma-assignor-repository'
+import { PrismaPayableRepository } from './prisma/repositories/prisma-payable-repository'
 import { PrismaUserRepository } from './prisma/repositories/prisma-user-repository'
 
 @Module({
@@ -12,7 +16,20 @@ import { PrismaUserRepository } from './prisma/repositories/prisma-user-reposito
       provide: UserRepository,
       useClass: PrismaUserRepository,
     },
+    {
+      provide: PayableRepository,
+      useClass: PrismaPayableRepository,
+    },
+    {
+      provide: AssignorRepository,
+      useClass: PrismaAssignorRepository,
+    },
   ],
-  exports: [PrismaService, UserRepository],
+  exports: [
+    PrismaService,
+    UserRepository,
+    PayableRepository,
+    AssignorRepository,
+  ],
 })
 export class DatabaseModule {}

--- a/src/infra/database/prisma/mappers/assignor-mapper.ts
+++ b/src/infra/database/prisma/mappers/assignor-mapper.ts
@@ -1,0 +1,34 @@
+import { EntityId } from '@/@shared/entities/entity-id'
+import { Assignor } from '@/domain/enterprise/entities/assignor'
+
+export class AssignorMapper {
+  static toDomain(raw) {
+    return Assignor.create(
+      {
+        name: raw.name,
+        email: raw.email,
+        phone: raw.phone,
+        document: raw.document,
+        creatorId: new EntityId(raw.creatorId),
+        active: raw.active,
+      },
+      new EntityId(raw.id),
+    )
+  }
+
+  static toPersistence(assignor: Assignor) {
+    return {
+      id: assignor.id.getValue(),
+      name: assignor.name,
+      email: assignor.email,
+      phone: assignor.phone,
+      document: assignor.document,
+      active: assignor.active,
+      creator: {
+        connect: {
+          id: assignor.creatorId.getValue(),
+        },
+      },
+    }
+  }
+}

--- a/src/infra/database/prisma/mappers/payable-mapper.ts
+++ b/src/infra/database/prisma/mappers/payable-mapper.ts
@@ -1,0 +1,38 @@
+import { EntityId } from '@/@shared/entities/entity-id'
+import { Payable } from '@/domain/enterprise/entities/payable'
+
+export class PayableMapper {
+  static toDomain(raw) {
+    return Payable.create(
+      {
+        value: raw.value,
+        active: raw.active,
+        received: raw.received,
+        receiverId: new EntityId(raw.receiverId),
+        assignorId: new EntityId(raw.assignorId),
+        emissionDate: raw.emissionDate.toString(),
+      },
+      new EntityId(raw.id),
+    )
+  }
+
+  static toPersistence(payable: Payable) {
+    return {
+      id: payable.id.getValue(),
+      value: payable.value,
+      active: payable.active,
+      received: payable.received,
+      emissionDate: payable.emissionDate,
+      receiver: {
+        connect: {
+          id: payable.receiverId.getValue(),
+        },
+      },
+      assignor: {
+        connect: {
+          id: payable.assignorId.getValue(),
+        },
+      },
+    }
+  }
+}

--- a/src/infra/database/prisma/repositories/prisma-assignor-repository.ts
+++ b/src/infra/database/prisma/repositories/prisma-assignor-repository.ts
@@ -1,0 +1,69 @@
+import {
+  AssignorRepository,
+  FindAssignorsResponse,
+} from '@/domain/application/repositories/assignor-repository'
+import { Assignor } from '@/domain/enterprise/entities/assignor'
+import { Injectable } from '@nestjs/common'
+import { AssignorMapper } from '../mappers/assignor-mapper'
+import { PrismaService } from '../prisma.service'
+
+@Injectable()
+export class PrismaAssignorRepository implements AssignorRepository {
+  constructor(private prisma: PrismaService) {}
+
+  async createAssignor(assignor: Assignor): Promise<Assignor> {
+    const createdAssignor = await this.prisma.assignor.create({
+      data: AssignorMapper.toPersistence(assignor),
+    })
+
+    return AssignorMapper.toDomain(createdAssignor)
+  }
+
+  async updateAssignor(id: string, assignor: Assignor): Promise<Assignor> {
+    const updatedAssignor = await this.prisma.assignor.update({
+      where: { id },
+      data: AssignorMapper.toPersistence(assignor),
+    })
+
+    return AssignorMapper.toDomain(updatedAssignor)
+  }
+
+  async deleteAssignor(id: string): Promise<boolean> {
+    const deletedAssignor = await this.prisma.assignor.delete({
+      where: { id },
+    })
+
+    return !!deletedAssignor
+  }
+
+  async findAssignorById(id: string, creatorId: string): Promise<Assignor> {
+    const assignor = await this.prisma.assignor.findFirst({
+      where: { id, creatorId },
+    })
+
+    if (!assignor) {
+      return null
+    }
+
+    return AssignorMapper.toDomain(assignor)
+  }
+
+  async findAssignors(
+    page: number,
+    limit: number,
+    creatorId: string,
+  ): Promise<FindAssignorsResponse> {
+    const assignors = await this.prisma.assignor.findMany({
+      where: { creatorId },
+      take: limit * 1,
+      skip: (page - 1) * limit,
+    })
+
+    const total = await this.prisma.assignor.count({ where: { creatorId } })
+
+    return {
+      assignors: assignors.map(AssignorMapper.toDomain),
+      assignorsCount: total,
+    }
+  }
+}

--- a/src/infra/database/prisma/repositories/prisma-payable-repository.ts
+++ b/src/infra/database/prisma/repositories/prisma-payable-repository.ts
@@ -1,0 +1,69 @@
+import {
+  FindPayablesResponse,
+  PayableRepository,
+} from '@/domain/application/repositories/payable-repository'
+import { Payable } from '@/domain/enterprise/entities/payable'
+import { Injectable } from '@nestjs/common'
+import { PayableMapper } from '../mappers/payable-mapper'
+import { PrismaService } from '../prisma.service'
+
+@Injectable()
+export class PrismaPayableRepository implements PayableRepository {
+  constructor(private prisma: PrismaService) {}
+
+  async createPayable(data: Payable): Promise<Payable> {
+    const createdPayable = await this.prisma.payable.create({
+      data: PayableMapper.toPersistence(data),
+    })
+
+    return PayableMapper.toDomain(createdPayable)
+  }
+
+  async findPayableById(id: string, receiverId: string): Promise<Payable> {
+    const payable = await this.prisma.payable.findFirst({
+      where: { id, receiverId },
+    })
+
+    if (!payable) {
+      return null
+    }
+
+    return PayableMapper.toDomain(payable)
+  }
+
+  async updatePayable(id: string, editedPayable: Payable): Promise<Payable> {
+    const updatedPayable = await this.prisma.payable.update({
+      where: { id },
+      data: PayableMapper.toPersistence(editedPayable),
+    })
+
+    return PayableMapper.toDomain(updatedPayable)
+  }
+
+  async deletePayable(id: string): Promise<boolean> {
+    const deletedPayable = await this.prisma.payable.delete({
+      where: { id },
+    })
+
+    return !!deletedPayable
+  }
+
+  async findPayables(
+    page: number,
+    limit: number,
+    receiverId: string,
+  ): Promise<FindPayablesResponse> {
+    const payables = await this.prisma.payable.findMany({
+      where: { receiverId },
+      take: limit,
+      skip: (page - 1) * limit,
+    })
+
+    const total = await this.prisma.payable.count({ where: { receiverId } })
+
+    return {
+      payables: payables.map(PayableMapper.toDomain),
+      payablesCount: total,
+    }
+  }
+}

--- a/src/infra/http/controllers/assignor/create-assignor/create-assignor.e2e.spec.ts
+++ b/src/infra/http/controllers/assignor/create-assignor/create-assignor.e2e.spec.ts
@@ -1,0 +1,60 @@
+import { AppModule } from '@/infra/app.module'
+import { DatabaseModule } from '@/infra/database/database.module'
+import { INestApplication } from '@nestjs/common'
+import { Test } from '@nestjs/testing'
+import * as request from 'supertest'
+
+describe('Create Assignor', () => {
+  let app: INestApplication
+
+  beforeEach(async () => {
+    const moduleRef = await Test.createTestingModule({
+      imports: [AppModule, DatabaseModule],
+      providers: [],
+    }).compile()
+
+    app = moduleRef.createNestApplication()
+
+    await app.init()
+  })
+
+  afterEach(async () => {
+    await app.close()
+  })
+
+  it('should be able to create a assignor', async () => {
+    await request(app.getHttpServer()).post('/users').send({
+      name: 'John Doe',
+      email: 'johndoe@johndoe.com',
+      password: '12345678',
+    })
+
+    const response = await request(app.getHttpServer()).post('/sessions').send({
+      email: 'johndoe@johndoe.com',
+      password: '12345678',
+    })
+
+    const { token } = response.body
+
+    const responseAssignor = await request(app.getHttpServer())
+      .post('/assignors')
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        name: 'John Doe',
+        email: 'johndoe@johndoe.com',
+        document: '12345678910',
+        phone: '12345678910',
+      })
+
+    expect(responseAssignor.status).toBe(201)
+    expect(responseAssignor.body).toEqual({
+      id: expect.any(String),
+      active: true,
+      name: 'John Doe',
+      email: 'johndoe@johndoe.com',
+      document: '12345678910',
+      phone: '12345678910',
+      creatorId: expect.any(String),
+    })
+  })
+})

--- a/src/infra/http/controllers/assignor/create-assignor/create-assignor.ts
+++ b/src/infra/http/controllers/assignor/create-assignor/create-assignor.ts
@@ -1,7 +1,6 @@
 import { CreateAssignorService } from '@/domain/application/services/assignor/create-assignor'
 import { CurrentUser } from '@/infra/auth/current-user-decorator'
 import { UserPayload } from '@/infra/auth/jwt-strategy'
-import { Public } from '@/infra/auth/public'
 import { ZodValidationPipe } from '@/infra/http/pipes/zod-validation-pipe'
 import { AssignorPresenter } from '@/infra/http/presenters/presenter-assignor'
 import { BadRequestException, Body, Controller, Post } from '@nestjs/common'
@@ -18,7 +17,6 @@ export type CreateAssignorDTO = z.infer<typeof createAssignorDTO>
 
 const bodyValidation = new ZodValidationPipe(createAssignorDTO)
 
-@Public()
 @Controller('/assignors')
 export class CreateAssignorController {
   constructor(private createAssignorService: CreateAssignorService) {}

--- a/src/infra/http/controllers/assignor/delete-assignor/delete-assignor.e2e.spec.ts
+++ b/src/infra/http/controllers/assignor/delete-assignor/delete-assignor.e2e.spec.ts
@@ -1,0 +1,99 @@
+import { AppModule } from '@/infra/app.module'
+import { DatabaseModule } from '@/infra/database/database.module'
+import { INestApplication } from '@nestjs/common'
+import { Test } from '@nestjs/testing'
+import * as request from 'supertest'
+
+describe('Delete Assignor', () => {
+  let app: INestApplication
+
+  beforeEach(async () => {
+    const moduleRef = await Test.createTestingModule({
+      imports: [AppModule, DatabaseModule],
+      providers: [],
+    }).compile()
+
+    app = moduleRef.createNestApplication()
+
+    await app.init()
+  })
+
+  afterEach(async () => {
+    await app.close()
+  })
+
+  it('should be able to delete a assignor', async () => {
+    await request(app.getHttpServer()).post('/users').send({
+      name: 'John Doe',
+      email: 'johndoe@johndoe.com',
+      password: '12345678',
+    })
+
+    const response = await request(app.getHttpServer()).post('/sessions').send({
+      email: 'johndoe@johndoe.com',
+      password: '12345678',
+    })
+
+    const { token } = response.body
+
+    const responseAssignor = await request(app.getHttpServer())
+      .post('/assignors')
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        name: 'John Doe',
+        email: 'johndoe@johndoe.com',
+        document: '12345678910',
+        phone: '12345678910',
+      })
+
+    const responseDeleteAssignor = await request(app.getHttpServer())
+      .delete('/assignors/' + responseAssignor.body.id)
+      .set('Authorization', `Bearer ${token}`)
+      .send()
+
+    expect(responseDeleteAssignor.status).toBe(204)
+  })
+
+  it('should be able to find a deleted assignor', async () => {
+    await request(app.getHttpServer()).post('/users').send({
+      name: 'John Doe',
+      email: 'johndoe@johndoe.com',
+      password: '12345678',
+    })
+
+    const response = await request(app.getHttpServer()).post('/sessions').send({
+      email: 'johndoe@johndoe.com',
+      password: '12345678',
+    })
+
+    const { token } = response.body
+
+    const responseAssignor = await request(app.getHttpServer())
+      .post('/assignors')
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        name: 'John Doe',
+        email: 'johndoe@johndoe.com',
+        document: '12345678910',
+        phone: '12345678910',
+      })
+
+    const responseDeleteAssignor = await request(app.getHttpServer())
+      .delete('/assignors/' + responseAssignor.body.id)
+      .set('Authorization', `Bearer ${token}`)
+      .send()
+
+    const responseFindAssignor = await request(app.getHttpServer())
+      .get('/assignors/' + responseAssignor.body.id)
+      .set('Authorization', `Bearer ${token}`)
+      .send()
+
+    expect(responseDeleteAssignor.status).toBe(204)
+    expect(responseFindAssignor.status).toBe(400)
+    expect(responseFindAssignor.body).toEqual({
+      message: 'Assignor non exists',
+      error: 'Bad Request',
+      statusCode: 400,
+    })
+  })
+})

--- a/src/infra/http/controllers/assignor/find-assignor-by-id/find-assignor-by-id.e2e.spec.ts
+++ b/src/infra/http/controllers/assignor/find-assignor-by-id/find-assignor-by-id.e2e.spec.ts
@@ -1,0 +1,67 @@
+import { AppModule } from '@/infra/app.module'
+import { DatabaseModule } from '@/infra/database/database.module'
+import { INestApplication } from '@nestjs/common'
+import { Test } from '@nestjs/testing'
+import * as request from 'supertest'
+
+describe('Delete Assignor', () => {
+  let app: INestApplication
+
+  beforeEach(async () => {
+    const moduleRef = await Test.createTestingModule({
+      imports: [AppModule, DatabaseModule],
+      providers: [],
+    }).compile()
+
+    app = moduleRef.createNestApplication()
+
+    await app.init()
+  })
+
+  afterEach(async () => {
+    await app.close()
+  })
+
+  it('should be able to find a assignor', async () => {
+    await request(app.getHttpServer()).post('/users').send({
+      name: 'John Doe',
+      email: 'johndoe@johndoe.com',
+      password: '12345678',
+    })
+
+    const response = await request(app.getHttpServer()).post('/sessions').send({
+      email: 'johndoe@johndoe.com',
+      password: '12345678',
+    })
+
+    const { token } = response.body
+
+    const responseAssignor = await request(app.getHttpServer())
+      .post('/assignors')
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        name: 'John Doe',
+        email: 'johndoe@johndoe.com',
+        document: '12345678910',
+        phone: '12345678910',
+      })
+
+    const responseFindAssignor = await request(app.getHttpServer())
+      .get('/assignors/' + responseAssignor.body.id)
+      .set('Authorization', `Bearer ${token}`)
+      .send()
+
+    expect(responseFindAssignor.status).toBe(200)
+    expect(responseFindAssignor.body).toEqual({
+      assignor: {
+        id: expect.any(String),
+        name: 'John Doe',
+        email: 'johndoe@johndoe.com',
+        document: '12345678910',
+        phone: '12345678910',
+        creatorId: expect.any(String),
+        active: true,
+      },
+    })
+  })
+})

--- a/src/infra/http/controllers/assignor/find-assignors/find-assignors.e2e.spec.ts
+++ b/src/infra/http/controllers/assignor/find-assignors/find-assignors.e2e.spec.ts
@@ -1,0 +1,74 @@
+import { AppModule } from '@/infra/app.module'
+import { DatabaseModule } from '@/infra/database/database.module'
+import { INestApplication } from '@nestjs/common'
+import { Test } from '@nestjs/testing'
+import * as request from 'supertest'
+
+describe('Delete Assignor', () => {
+  let app: INestApplication
+
+  beforeEach(async () => {
+    const moduleRef = await Test.createTestingModule({
+      imports: [AppModule, DatabaseModule],
+      providers: [],
+    }).compile()
+
+    app = moduleRef.createNestApplication()
+
+    await app.init()
+  })
+
+  afterEach(async () => {
+    await app.close()
+  })
+
+  it('should be able to find a assignor', async () => {
+    await request(app.getHttpServer()).post('/users').send({
+      name: 'John Doe',
+      email: 'johndoe@johndoe.com',
+      password: '12345678',
+    })
+
+    const response = await request(app.getHttpServer()).post('/sessions').send({
+      email: 'johndoe@johndoe.com',
+      password: '12345678',
+    })
+
+    const { token } = response.body
+
+    const responseAssignor = await request(app.getHttpServer())
+      .post('/assignors')
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        name: 'John Doe',
+        email: 'johndoe@johndoe.com',
+        document: '12345678910',
+        phone: '12345678910',
+      })
+
+    const responseFindAssignor = await request(app.getHttpServer())
+      .get('/assignors')
+      .set('Authorization', `Bearer ${token}`)
+      .query({
+        page: 1,
+        limit: 10,
+      })
+      .send()
+
+    expect(responseFindAssignor.status).toBe(200)
+    expect(responseFindAssignor.body).toEqual({
+      assignors: [
+        {
+          id: expect.any(String),
+          name: 'John Doe',
+          email: 'johndoe@johndoe.com',
+          document: '12345678910',
+          phone: '12345678910',
+          creatorId: expect.any(String),
+          active: true,
+        },
+      ],
+      assignorsCount: 1,
+    })
+  })
+})

--- a/src/infra/http/controllers/assignor/update-assignor/update-assignor.e2e.spec.ts
+++ b/src/infra/http/controllers/assignor/update-assignor/update-assignor.e2e.spec.ts
@@ -1,0 +1,67 @@
+import { AppModule } from '@/infra/app.module'
+import { DatabaseModule } from '@/infra/database/database.module'
+import { INestApplication } from '@nestjs/common'
+import { Test } from '@nestjs/testing'
+import * as request from 'supertest'
+
+describe('Update Assignor', () => {
+  let app: INestApplication
+
+  beforeEach(async () => {
+    const moduleRef = await Test.createTestingModule({
+      imports: [AppModule, DatabaseModule],
+      providers: [],
+    }).compile()
+
+    app = moduleRef.createNestApplication()
+
+    await app.init()
+  })
+
+  afterEach(async () => {
+    await app.close()
+  })
+
+  it('should be able to update a assignor', async () => {
+    await request(app.getHttpServer()).post('/users').send({
+      name: 'John Doe',
+      email: 'johndoe@johndoe.com',
+      password: '12345678',
+    })
+
+    const response = await request(app.getHttpServer()).post('/sessions').send({
+      email: 'johndoe@johndoe.com',
+      password: '12345678',
+    })
+
+    const { token } = response.body
+
+    const responseAssignor = await request(app.getHttpServer())
+      .post('/assignors')
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        name: 'John Doe',
+        email: 'johndoe@johndoe.com',
+        document: '12345678910',
+        phone: '12345678910',
+      })
+
+    const responseUpdateAssignor = await request(app.getHttpServer())
+      .patch(`/assignors/${responseAssignor.body.id}`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        name: 'John Doe2',
+      })
+
+    expect(responseAssignor.status).toBe(201)
+    expect(responseUpdateAssignor.body).toEqual({
+      id: expect.any(String),
+      active: true,
+      name: 'John Doe2',
+      email: 'johndoe@johndoe.com',
+      document: '12345678910',
+      phone: '12345678910',
+      creatorId: expect.any(String),
+    })
+  })
+})

--- a/src/infra/http/controllers/assignor/update-assignor/update-assignor.ts
+++ b/src/infra/http/controllers/assignor/update-assignor/update-assignor.ts
@@ -14,10 +14,10 @@ import {
 import { z } from 'zod'
 
 const updateAssignorDTO = z.object({
-  name: z.string().min(2).max(140),
-  email: z.string().email().max(140),
-  document: z.string().max(30),
-  phone: z.string().max(20),
+  name: z.string().min(2).max(140).optional(),
+  email: z.string().email().max(140).optional(),
+  document: z.string().max(30).optional(),
+  phone: z.string().max(20).optional(),
 })
 
 export type UpdateAssignorDTO = z.infer<typeof updateAssignorDTO>

--- a/src/infra/http/controllers/payable/create-payable/create-payable.e2e.spec.ts
+++ b/src/infra/http/controllers/payable/create-payable/create-payable.e2e.spec.ts
@@ -1,0 +1,68 @@
+import { AppModule } from '@/infra/app.module'
+import { DatabaseModule } from '@/infra/database/database.module'
+import { INestApplication } from '@nestjs/common'
+import { Test } from '@nestjs/testing'
+import * as request from 'supertest'
+
+describe('Create Payable', () => {
+  let app: INestApplication
+
+  beforeEach(async () => {
+    const moduleRef = await Test.createTestingModule({
+      imports: [AppModule, DatabaseModule],
+      providers: [],
+    }).compile()
+
+    app = moduleRef.createNestApplication()
+
+    await app.init()
+  })
+
+  afterEach(async () => {
+    await app.close()
+  })
+
+  it('should be able to create a payable', async () => {
+    await request(app.getHttpServer()).post('/users').send({
+      name: 'John Doe',
+      email: 'johndoe@johndoe.com',
+      password: '12345678',
+    })
+
+    const response = await request(app.getHttpServer()).post('/sessions').send({
+      email: 'johndoe@johndoe.com',
+      password: '12345678',
+    })
+
+    const { token } = response.body
+
+    const responseAssignor = await request(app.getHttpServer())
+      .post('/assignors')
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        name: 'John Doe',
+        email: 'johndoe@johndoe.com',
+        document: '12345678910',
+        phone: '12345678910',
+      })
+
+    const responsePayable = await request(app.getHttpServer())
+      .post('/payables')
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        value: 1000,
+        assignorId: responseAssignor.body.id,
+      })
+
+    expect(responsePayable.status).toBe(201)
+    expect(responsePayable.body).toEqual({
+      id: expect.any(String),
+      active: true,
+      value: 1000,
+      emissionDate: expect.any(String),
+      assignorId: responseAssignor.body.id,
+      receiverId: expect.any(String),
+      received: false,
+    })
+  })
+})

--- a/src/infra/http/controllers/payable/create-payable/create-payable.ts
+++ b/src/infra/http/controllers/payable/create-payable/create-payable.ts
@@ -12,7 +12,6 @@ import { z } from 'zod'
 
 const createPayableDTO = z.object({
   value: z.number(),
-  emissionDate: z.date(),
   assignorId: z.string().uuid(),
 })
 
@@ -29,13 +28,12 @@ export class CreatePayableController {
     @Body(bodyValidation) body: CreatePayableDTO,
     @CurrentUser() user: UserPayload,
   ) {
-    const { assignorId, emissionDate, value } = body
+    const { assignorId, value } = body
 
     const { sub } = user
 
     const payable = await this.createPayableService.execute({
       assignorId,
-      emissionDate,
       receiverId: sub,
       value,
     })


### PR DESCRIPTION
This commit adds the `emissionDate` field to the `create` method of the `Payable` entity in the `payable.ts` file. The `emissionDate` is now an optional property in the `PayableProps` type, allowing it to be passed when creating a new `Payable` instance. If no `emissionDate` is provided, the current date is used as the default value.